### PR TITLE
fix test testFormat_MixedStyle

### DIFF
--- a/src/test/java/net/socialgamer/pyx/importer/RichTextToHtmlFormatHelperTest.java
+++ b/src/test/java/net/socialgamer/pyx/importer/RichTextToHtmlFormatHelperTest.java
@@ -93,7 +93,7 @@ public class RichTextToHtmlFormatHelperTest {
     rtf.append("Italic. ", italic);
     rtf.append("Underline.", underline);
     rtf.append(" More plain.");
-    assertEquals("Plain. <i>Italic. </i><u>Underline.</u> More plain.", helper.format(rtf));
+    assertEquals("Plain. <i>Italic.</i> <u>Underline.</u> More plain.", helper.format(rtf));
   }
 
   @Test


### PR DESCRIPTION
The test `testFormat_MixedStyle` fails because the assertion compares to a string with a space before `</i> instead of after `</i>`. This commit fixes the typo.